### PR TITLE
Update openstack_hosts_configure_dnf.yml

### DIFF
--- a/tasks/openstack_hosts_configure_dnf.yml
+++ b/tasks/openstack_hosts_configure_dnf.yml
@@ -102,7 +102,7 @@
     - (install_method | default('source')) == 'distro'
 
 - name: Enable PowerTools repository
-  command: dnf config-manager --set-enabled PowerTools
+  command: dnf config-manager --set-enabled powertools
   changed_when: false
   when:
     - openstack_hosts_power_tool_enable | bool


### PR DESCRIPTION
If running inside a container, the command dnf repolist --all shows the PowerTools repo to be actually named powertools, with lower case P and T.  Please just take a look.